### PR TITLE
parametrize build JDK via -Pjdk.version, run CI JDK matrix as parallel jobs

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -11,7 +11,12 @@ env:
 
 jobs:
   gradle:
+    name: JDK ${{ matrix.jdk }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [17, 21, 25]
     steps:
       - uses: actions/checkout@v4
 
@@ -19,9 +24,8 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: | # the last one is default
-            25
-            21
+          java-version: | # the last one is default: Gradle itself runs on 17, the matrix JDK is consumed as a toolchain via -Pjdk.version
+            ${{ matrix.jdk }}
             17
           cache: gradle
 
@@ -31,21 +35,20 @@ jobs:
           add-job-summary-as-pr-comment: on-failure
 
       - name: Gradle toolchains info
-        run: ./gradlew -q javaToolchains
+        run: ./gradlew -q javaToolchains -Pjdk.version=${{ matrix.jdk }}
 
       - name: Gradle build environment info
         run: ./gradlew -q buildEnvironment
 
       - name: Execute Gradle build
-        run: ./gradlew --continue build
+        run: ./gradlew --continue build -Pjdk.version=${{ matrix.jdk }}
 
       - name: Upload Test Report
         uses: actions/upload-artifact@v4
         if: always() # always run even if the previous step fails
         with:
-          name: junit-test-results
+          name: junit-test-results-jdk${{ matrix.jdk }}
           path: |
             **/build/test-results/test/TEST-*.xml
-            **/build/test-results/test-jdk*/TEST-*.xml
           retention-days: 1
           overwrite: true

--- a/buildSrc/src/main/kotlin/framefork.java.gradle.kts
+++ b/buildSrc/src/main/kotlin/framefork.java.gradle.kts
@@ -19,12 +19,15 @@ repositories {
     mavenLocal()
 }
 
+// bytecode target stays at the minimal supported Java; the toolchain JDK is parametrized so CI can run the same build on newer JDKs
+val jdkVersion = (findProperty("jdk.version") as String?)?.toInt() ?: 17
+
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
 
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(jdkVersion)
     }
 }
 
@@ -177,25 +180,7 @@ tasks.withType<Javadoc> {
 }
 
 tasks.named("test") {
-    description = "Runs the tests against the default JDK"
-}
-
-for (javaVersion in listOf(21, 25)) {
-    val testTask = tasks.register<Test>("test-jdk${javaVersion}") {
-        group = "Verification"
-        description = "Runs the tests against JDK $javaVersion"
-
-        javaLauncher.set(javaToolchains.launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(javaVersion))
-        })
-
-        testClassesDirs = sourceSets.test.get().output.classesDirs
-        classpath = sourceSets.test.get().runtimeClasspath
-    }
-
-    tasks.named("check") {
-        dependsOn(testTask)
-    }
+    description = "Runs the tests against the configured JDK toolchain"
 }
 
 tasks.withType<Test>() {

--- a/modules/typed-ids-hibernate-62/src/testFixtures/java/org/framefork/typedIds/bigint/hibernate/basic/BigIntPooledLoMismatchEntity.java
+++ b/modules/typed-ids-hibernate-62/src/testFixtures/java/org/framefork/typedIds/bigint/hibernate/basic/BigIntPooledLoMismatchEntity.java
@@ -11,7 +11,7 @@ import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
 import org.jspecify.annotations.Nullable;
 
-@SuppressWarnings({"removal","UnnecessarilyFullyQualified"})
+@SuppressWarnings({"deprecation","removal","UnnecessarilyFullyQualified"})
 @Entity
 @Table(name = BigIntPooledLoMismatchEntity.TABLE_NAME)
 public class BigIntPooledLoMismatchEntity

--- a/modules/typed-ids-hibernate-62/src/testFixtures/java/org/framefork/typedIds/bigint/hibernate/basic/BigIntPooledLoOptimizerEntity.java
+++ b/modules/typed-ids-hibernate-62/src/testFixtures/java/org/framefork/typedIds/bigint/hibernate/basic/BigIntPooledLoOptimizerEntity.java
@@ -11,7 +11,7 @@ import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
 import org.jspecify.annotations.Nullable;
 
-@SuppressWarnings({"removal","UnnecessarilyFullyQualified"})
+@SuppressWarnings({"deprecation","removal","UnnecessarilyFullyQualified"})
 @Entity
 @Table(name = BigIntPooledLoOptimizerEntity.TABLE_NAME)
 public class BigIntPooledLoOptimizerEntity

--- a/modules/typed-ids-hibernate-63/src/testFixtures/java/org/framefork/typedIds/bigint/hibernate/basic/BigIntPooledLoMismatchEntity.java
+++ b/modules/typed-ids-hibernate-63/src/testFixtures/java/org/framefork/typedIds/bigint/hibernate/basic/BigIntPooledLoMismatchEntity.java
@@ -11,7 +11,7 @@ import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
 import org.jspecify.annotations.Nullable;
 
-@SuppressWarnings({"removal","UnnecessarilyFullyQualified"})
+@SuppressWarnings({"deprecation","removal","UnnecessarilyFullyQualified"})
 @Entity
 @Table(name = BigIntPooledLoMismatchEntity.TABLE_NAME)
 public class BigIntPooledLoMismatchEntity

--- a/modules/typed-ids-hibernate-63/src/testFixtures/java/org/framefork/typedIds/bigint/hibernate/basic/BigIntPooledLoOptimizerEntity.java
+++ b/modules/typed-ids-hibernate-63/src/testFixtures/java/org/framefork/typedIds/bigint/hibernate/basic/BigIntPooledLoOptimizerEntity.java
@@ -11,7 +11,7 @@ import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
 import org.jspecify.annotations.Nullable;
 
-@SuppressWarnings({"removal","UnnecessarilyFullyQualified"})
+@SuppressWarnings({"deprecation","removal","UnnecessarilyFullyQualified"})
 @Entity
 @Table(name = BigIntPooledLoOptimizerEntity.TABLE_NAME)
 public class BigIntPooledLoOptimizerEntity


### PR DESCRIPTION
## What & why

The build previously ran the whole test suite **three times inside every `gradlew build`** — the convention plugin registered `test-jdk21`/`test-jdk25` task variants and wired them into `check`, so both local builds and the single CI job paid the full multi-JDK cost serially. The build got long, and it's about to get longer (more testing modules are planned).

This changes the strategy:

- **Local**: `gradlew build` runs everything once, on the minimal supported JDK (17).
- **CI**: a parallel matrix job per supported JDK (17 / 21 / 25), each running the full build on that JDK via `-Pjdk.version=NN` (`fail-fast: false`, per-JDK test-report artifacts).

## How

- `framefork.java.gradle.kts`: the toolchain `languageVersion` is now driven by the `jdk.version` Gradle property (default 17); the `test-jdkNN` task registrations and their `check` wiring are removed. `sourceCompatibility`/`targetCompatibility` stay pinned at 17, so the produced bytecode never drifts with the toolchain.
- `gradle-build.yml`: single three-JDK job → matrix. Gradle itself keeps running on JDK 17 in every job (installed alongside the matrix JDK); the matrix JDK is consumed as a toolchain.

Note one semantic upgrade: previously JDKs 21/25 only *ran tests* against 17-compiled classes; now each matrix job compiles (incl. errorprone) and tests entirely under its JDK, which is a stronger compatibility signal.

## Verified

- default build → `Used JDK: 17.0.17+10 Eclipse Temurin`
- `-Pjdk.version=21` → `Used JDK: 21.0.10+7-LTS` for compile, `Using JDK: 21.0.10+7-LTS` for tests (97 tests passed)
- `check --dry-run` task graph contains no `test-jdkNN` tasks; no deprecation warnings

https://claude.ai/code/session_012xE9NcN8chCvge4fTGGu7b