### PR TITLE
ci: match the per-JDK test-report artifacts in the results publisher

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Download Test Report
         uses: dawidd6/action-download-artifact@v9
         with:
-          name: junit-test-results
+          name: junit-test-results.*
+          name_is_regexp: true
           run_id: ${{ github.event.workflow_run.id }}
 
       - name: Publish Test Report


### PR DESCRIPTION
## What broke

The build-parallelization migration renamed the test-report artifact in `gradle-build.yml` from `junit-test-results` to per-matrix-cell names (`junit-test-results-jdk${{ matrix.jdk }}`), but the `workflow_run`-triggered publisher in `publish-test-results.yml` still downloads by the exact name `junit-test-results` via `dawidd6/action-download-artifact`. No artifact matches, so every "Publish Test Results" run now fails.

## The fix

Switch the download step to a regex match (`name: junit-test-results.*` with `name_is_regexp: true`). With `name_is_regexp`, each matched artifact is extracted into a subdirectory named after itself, and the downstream `report_paths: '**/build/test-results/test/TEST-*.xml'` glob still matches inside those subdirectories — the published report now covers the results from all matrix JDKs.

## Verification caveat

`workflow_run` workflows always execute the **default branch's** workflow definition, so this fix only takes effect after merge — this PR itself cannot demonstrate the publisher passing. The red "Publish Test Results" run that appears alongside this PR's checks is the pre-fix master definition failing, i.e. exactly the symptom this PR fixes.