### PR TITLE
ci: run the dependency-submission Gradle on a JVM that can resolve the build plugin

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: temurin
-        java-version: 17
+        java-version: 25
 
     - name: Generate and submit dependency graph
       id: dependency-submission


### PR DESCRIPTION
Since the migration to `org.framefork.build` merged, the Dependency Submission workflow fails on master: the plugin's module metadata declares `org.gradle.jvm.version = 21`, so a Gradle daemon on Java 17 cannot resolve it at all (`Dependency requires at least JVM runtime version 21. This build uses a Java 17 JVM.`).

This bumps the workflow's `setup-java` to 25 — matching the repo's `framefork { jdkVersion = 25 }`, so the same JVM serves as both the Gradle daemon (≥ 21, resolves the plugin) and the compile toolchain (the plugin disables toolchain auto-download). The sibling repos on `jdkVersion = 21` already run this workflow on 21 and pass.

Verification caveat: this workflow only runs on push to master, so like the publisher fix, it demonstrates itself after merge.
