### PR TITLE
Adopt org.framefork.build 0.4.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,26 +5,9 @@ plugins {
 }
 
 group = "org.framefork"
-version = providers.gradleProperty("version").get().trim()
 
 allprojects {
     group = rootProject.group
-    version = rootProject.version
-}
-
-tasks.withType<Wrapper> {
-    distributionType = Wrapper.DistributionType.ALL
-}
-
-allprojects {
-    apply(plugin = "project-report")
-
-    this.tasks.register<DependencyReportTask>("allDependencies") {
-        evaluationDependsOnChildren()
-        this.setRenderer(org.gradle.api.tasks.diagnostics.internal.dependencies.AsciiDependencyReportRenderer().apply {
-            outputFile = file(project.layout.buildDirectory.file("reports/dependencies.txt"))
-        })
-    }
 }
 
 gradle.projectsEvaluated {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,13 +9,3 @@ group = "org.framefork"
 allprojects {
     group = rootProject.group
 }
-
-gradle.projectsEvaluated {
-    // Make sure tests of individual modules are executed sequentially
-    val testTasks = subprojects
-        .flatMap { it.tasks.withType<Test>() }
-        .sortedBy { it.project.path } // Sort to ensure a consistent order
-    for (i in 1 until testTasks.size) {
-        testTasks[i].mustRunAfter(testTasks[i - 1])
-    }
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-googleAutoService = "1.1.1"
 errorProne = "2.35.1"
 junit-jupiter = "5.10.3"
 jackson = "2.18.1"
@@ -12,8 +11,6 @@ jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.0.
 jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson" }
 jackson-annotations = { group = "com.fasterxml.jackson.core", name = "jackson-annotations", version.ref = "jackson" }
 gson = { module = "com.google.code.gson:gson", version = "2.10.1" }
-autoService-processor = { group = "com.google.auto.service", name = "auto-service", version.ref = "googleAutoService" }
-autoService-annotations = { group = "com.google.auto.service", name = "auto-service-annotations", version.ref = "googleAutoService" }
 errorprone-annotations = { group = "com.google.errorprone", name = "error_prone_annotations", version.ref = "errorProne" }
 ateoClassindex = { group = "org.atteo.classindex", name = "classindex", version = "3.13" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }

--- a/modules/typed-ids-hibernate-61/build.gradle.kts
+++ b/modules/typed-ids-hibernate-61/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.framefork.build.library-published")
+    id("org.framefork.build.auto-service")
     id("java-test-fixtures")
 }
 
@@ -18,9 +19,6 @@ dependencies {
     }
 
     compileOnly(libs.jetbrains.annotations)
-
-    compileOnly(libs.autoService.annotations)
-    annotationProcessor(libs.autoService.processor)
 
     testImplementation(project(":typed-ids-hibernate-61-testing"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/modules/typed-ids-hibernate-62/build.gradle.kts
+++ b/modules/typed-ids-hibernate-62/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.framefork.build.library-published")
+    id("org.framefork.build.auto-service")
     id("java-test-fixtures")
 }
 
@@ -8,9 +9,6 @@ dependencies {
     api(libs.hibernate.orm.v62)
 
     compileOnly(libs.jetbrains.annotations)
-
-    compileOnly(libs.autoService.annotations)
-    annotationProcessor(libs.autoService.processor)
 
     testImplementation(project(":typed-ids-hibernate-62-testing"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/modules/typed-ids-hibernate-63/build.gradle.kts
+++ b/modules/typed-ids-hibernate-63/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.framefork.build.library-published")
+    id("org.framefork.build.auto-service")
     id("java-test-fixtures")
 }
 
@@ -8,9 +9,6 @@ dependencies {
     api(libs.hibernate.orm.v63)
 
     compileOnly(libs.jetbrains.annotations)
-
-    compileOnly(libs.autoService.annotations)
-    annotationProcessor(libs.autoService.processor)
 
     testImplementation(project(":typed-ids-hibernate-63-testing"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/modules/typed-ids-hibernate-70/build.gradle.kts
+++ b/modules/typed-ids-hibernate-70/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.framefork.build.library-published")
+    id("org.framefork.build.auto-service")
     id("java-test-fixtures")
 }
 
@@ -9,9 +10,6 @@ dependencies {
     compileOnly(libs.hibernate.models.v70) // this is really a runtime dependency, but in runtime the version from hibernate is provided
 
     compileOnly(libs.jetbrains.annotations)
-
-    compileOnly(libs.autoService.annotations)
-    annotationProcessor(libs.autoService.processor)
 
     testImplementation(project(":typed-ids-hibernate-70-testing"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/modules/typed-ids-hibernate-72/build.gradle.kts
+++ b/modules/typed-ids-hibernate-72/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.framefork.build.library-published")
+    id("org.framefork.build.auto-service")
     id("java-test-fixtures")
 }
 
@@ -9,9 +10,6 @@ dependencies {
     compileOnly(libs.hibernate.models.v70) // this is really a runtime dependency, but in runtime the version from hibernate is provided
 
     compileOnly(libs.jetbrains.annotations)
-
-    compileOnly(libs.autoService.annotations)
-    annotationProcessor(libs.autoService.processor)
 
     testImplementation(project(":typed-ids-hibernate-72-testing"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/modules/typed-ids-index-java-classes-processor/build.gradle.kts
+++ b/modules/typed-ids-index-java-classes-processor/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.framefork.build.library-published")
+    id("org.framefork.build.auto-service")
 }
 
 dependencies {
@@ -9,9 +10,6 @@ dependencies {
     api(libs.ateoClassindex)
 
     compileOnly(libs.jetbrains.annotations)
-
-    compileOnly(libs.autoService.annotations)
-    annotationProcessor(libs.autoService.processor)
 }
 
 project.description = "TypeIds for safer code - Java Compiler Annotation Processor for indexing your TypedId classes"

--- a/modules/typed-ids-openapi-springdoc/build.gradle.kts
+++ b/modules/typed-ids-openapi-springdoc/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.framefork.build.library-published")
+    id("org.framefork.build.auto-service")
 }
 
 dependencies {
@@ -8,9 +9,6 @@ dependencies {
     api(libs.springdoc.openapi.starter.common)
 
     compileOnly(libs.jetbrains.annotations)
-
-    compileOnly(libs.autoService.annotations)
-    annotationProcessor(libs.autoService.processor)
     annotationProcessor(libs.springdoc.openapi.spring.configuration.processor)
 
     testImplementation(project(":typed-ids-testing"))

--- a/modules/typed-ids-openapi-swagger-jakarta/build.gradle.kts
+++ b/modules/typed-ids-openapi-swagger-jakarta/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.framefork.build.library-published")
+    id("org.framefork.build.auto-service")
 }
 
 dependencies {
@@ -7,9 +8,6 @@ dependencies {
     api(libs.swagger.v3.core.jakarta)
 
     compileOnly(libs.jetbrains.annotations)
-
-    compileOnly(libs.autoService.annotations)
-    annotationProcessor(libs.autoService.processor)
 
     testImplementation(project(":typed-ids-testing"))
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/modules/typed-ids/build.gradle.kts
+++ b/modules/typed-ids/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("org.framefork.build.library-published")
+    id("org.framefork.build.auto-service")
 }
 
 dependencies {
@@ -9,9 +10,6 @@ dependencies {
     compileOnly(libs.hypersistence.tsid)
 
     compileOnly(libs.jetbrains.annotations)
-
-    compileOnly(libs.autoService.annotations)
-    annotationProcessor(libs.autoService.processor)
 
     compileOnly(libs.jackson.databind)
     compileOnly(libs.gson)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.framefork.build") version "0.2.0"
+    id("org.framefork.build") version "0.4.0"
 }
 
 framefork {


### PR DESCRIPTION
## What changed

- Bump `org.framefork.build` to `0.4.0`, resolved from Maven Central (dropped the local `mavenLocal()` + `-SNAPSHOT` scaffolding used during pre-release verification).
- Drop root-build boilerplate now provided by the convention plugin: project versioning from `gradle.properties`, the per-project `allDependencies` report task, and the Gradle wrapper `ALL` distribution setting.
- Replace the hand-rolled `gradle.projectsEvaluated { mustRunAfter }` test-ordering chain with the plugin's default cross-module test serialization. The plugin uses a shared one-permit `BuildService`, so it enforces mutual exclusion (at most one `Test` task at a time, everything else stays parallel) rather than a fixed order — immune to the chain breaking when only a subset of module test tasks is run. `sequentialTests` defaults to `true` in 0.4.0, so no explicit knob is needed.
- Adopt the `org.framefork.build.auto-service` feature plugin: modules apply the plugin ID instead of hand-declaring the Google `@AutoService` `compileOnly` annotations + `annotationProcessor` at managed versions.

## Verification

- `./gradlew --refresh-dependencies build` against Maven Central — BUILD SUCCESSFUL (full build; doclint issue is fixed).
- `./gradlew resolveAndLockAll --write-locks --no-configuration-cache` — zero lockfile diff (dependency locking is on).
- No `mavenLocal()` or plugin `SNAPSHOT` references remain; the only `-SNAPSHOT` left is the repo's own project version in `gradle.properties`.

## Release notes

- v0.3.0: https://github.com/framefork/framefork-gradle-plugins/releases/tag/v0.3.0
- v0.4.0 (`sequentialTests` now defaults to `true`): https://github.com/framefork/framefork-gradle-plugins/releases/tag/v0.4.0